### PR TITLE
Add action/target style constructor

### DIFF
--- a/MSWeakTimer.h
+++ b/MSWeakTimer.h
@@ -28,6 +28,14 @@
                                         repeats:(BOOL)repeats
                                   dispatchQueue:(dispatch_queue_t)dispatchQueue;
 
++ (MSWeakTimer *)scheduledTimerWithTimeInterval:(NSTimeInterval)timeInterval
+                                       target:(id)target
+                                       selector:(SEL)selector
+                                       userInfo:(id)userInfo
+                                        repeats:(BOOL)repeats
+                                  dispatchQueue:(dispatch_queue_t)dispatchQueue;
+
+
 /**
  * @discussion causes the timer to be fired synchronously with this call.
  * @note this fires the timer on the caller queue, not on the provided dispatch_queue.


### PR DESCRIPTION
Action/target is easier to use than delegate style when you have more than one timer for a given object. The delegate style forces you to use userInfo + error prone routing conditions.
