### PR TITLE
Added support for scheduling blocks to be called when the timer fires

### DIFF
--- a/MSWeakTimer.h
+++ b/MSWeakTimer.h
@@ -8,6 +8,10 @@
 
 #import <Foundation/Foundation.h>
 
+@class MSWeakTimer;
+
+typedef void(^MSWeakTimerBlock)(MSWeakTimer *timer);
+
 /**
  `MSWeakTimer` behaves similar to an `NSTimer` but doesn't retain the target.
  This timer is implemented using GCD, so you can schedule and unschedule it on arbitrary queues (unlike regular NSTimers!)
@@ -31,11 +35,33 @@
              dispatchQueue:(dispatch_queue_t)dispatchQueue;
 
 /**
+ * Creates a timer that calls the specified block on the specified dispatch queue when fired, and waits for a call to `-schedule` to start ticking.
+ * @param timeInterval how frequently `block` will be called. If the timer doens't repeat, it will only be called once, approximately `timeInterval` seconds from the time you call this method.
+ * @param repeats if `YES`, `block` will be called until the `MSWeakTimer` object is deallocated or until you call `invalidate`. If `NO`, it will only be called once.
+ * @param dispatchQueue the queue where the `block` will be called. It can be either a serial or concurrent queue.
+ * @see `invalidate`.
+ */
+- (id)initWithTimeInterval:(NSTimeInterval)timeInterval
+                     block:(MSWeakTimerBlock)block
+                  userInfo:(id)userInfo
+                   repeats:(BOOL)repeats
+             dispatchQueue:(dispatch_queue_t)dispatchQueue;
+
+/**
  * Creates an `MSWeakTimer` object and schedules it to start ticking inmediately.
  */
 + (instancetype)scheduledTimerWithTimeInterval:(NSTimeInterval)timeInterval
                                         target:(id)target
                                       selector:(SEL)selector
+                                      userInfo:(id)userInfo
+                                       repeats:(BOOL)repeats
+                                 dispatchQueue:(dispatch_queue_t)dispatchQueue;
+
+/**
+ * Creates an `MSWeakTimer` object with a block and schedules it to start ticking inmediately.
+ */
++ (instancetype)scheduledTimerWithTimeInterval:(NSTimeInterval)timeInterval
+                                         block:(MSWeakTimerBlock)block
                                       userInfo:(id)userInfo
                                        repeats:(BOOL)repeats
                                  dispatchQueue:(dispatch_queue_t)dispatchQueue;
@@ -63,7 +89,7 @@
 /**
  * You can call this method on repeatable timers in order to stop it from running and trying
  * to call the delegate method.
- * @note `MSWeakTimer` won't invoke the `selector` on `target` again after calling this method.
+ * @note `MSWeakTimer` won't invoke the `selector` on `target` or `block` again after calling this method.
  * You can call this method from any queue, it doesn't have to be the queue from where you scheduled it.
  * Since it doesn't retain the delegate, unlike a regular `NSTimer`, your `dealloc` method will actually be called
  * and it's easier to place the `invalidate` call there, instead of figuring out a safe place to do it.

--- a/MSWeakTimer.h
+++ b/MSWeakTimer.h
@@ -22,7 +22,7 @@ typedef void(^MSWeakTimerBlock)(MSWeakTimer *timer);
  * Creates a timer with the specified parameters and waits for a call to `-schedule` to start ticking.
  * @note It's safe to retain the returned timer by the object that is also the target.
  * or the provided `dispatchQueue`.
- * @param timeInterval how frequently `selector` will be invoked on `target`. If the timer doens't repeat, it will only be invoked once, approximately `timeInterval` seconds from the time you call this method.
+ * @param timeInterval how frequently `selector` will be invoked on `target`. If the timer doesn't repeat, it will only be invoked once, approximately `timeInterval` seconds from the time you call this method.
  * @param repeats if `YES`, `selector` will be invoked on `target` until the `MSWeakTimer` object is deallocated or until you call `invalidate`. If `NO`, it will only be invoked once.
  * @param dispatchQueue the queue where the delegate method will be dispatched. It can be either a serial or concurrent queue.
  * @see `invalidate`.
@@ -36,7 +36,7 @@ typedef void(^MSWeakTimerBlock)(MSWeakTimer *timer);
 
 /**
  * Creates a timer that calls the specified block on the specified dispatch queue when fired, and waits for a call to `-schedule` to start ticking.
- * @param timeInterval how frequently `block` will be called. If the timer doens't repeat, it will only be called once, approximately `timeInterval` seconds from the time you call this method.
+ * @param timeInterval how frequently `block` will be called. If the timer doesn't repeat, it will only be called once, approximately `timeInterval` seconds from the time you call this method.
  * @param repeats if `YES`, `block` will be called until the `MSWeakTimer` object is deallocated or until you call `invalidate`. If `NO`, it will only be called once.
  * @param dispatchQueue the queue where the `block` will be called. It can be either a serial or concurrent queue.
  * @see `invalidate`.
@@ -48,7 +48,7 @@ typedef void(^MSWeakTimerBlock)(MSWeakTimer *timer);
              dispatchQueue:(dispatch_queue_t)dispatchQueue;
 
 /**
- * Creates an `MSWeakTimer` object and schedules it to start ticking inmediately.
+ * Creates an `MSWeakTimer` object and schedules it to start ticking immediately.
  */
 + (instancetype)scheduledTimerWithTimeInterval:(NSTimeInterval)timeInterval
                                         target:(id)target
@@ -58,7 +58,7 @@ typedef void(^MSWeakTimerBlock)(MSWeakTimer *timer);
                                  dispatchQueue:(dispatch_queue_t)dispatchQueue;
 
 /**
- * Creates an `MSWeakTimer` object with a block and schedules it to start ticking inmediately.
+ * Creates an `MSWeakTimer` object with a block and schedules it to start ticking immediately.
  */
 + (instancetype)scheduledTimerWithTimeInterval:(NSTimeInterval)timeInterval
                                          block:(MSWeakTimerBlock)block

--- a/MSWeakTimer.m
+++ b/MSWeakTimer.m
@@ -242,7 +242,7 @@
 
 - (void)timerFired
 {
-    // Checking attomatically if the timer has already been invalidated.
+    // Checking atomically if the timer has already been invalidated.
     if (OSAtomicAnd32OrigBarrier(1, &_timerFlags.timerIsInvalidated))
     {
         return;


### PR DESCRIPTION
After I stumbled upon this great library via CocoaPods, I've realized that it would be much easier for me to use the timer via "scheduling" a block. I know that there's dispatch_after, but I really want a clean way to cancel the scheduled block (actually cancel, not make it just skip everything when it's eventually fired anyway). So I've added some more code into the class, trying to keep it analogous to the existing one.
If you think these changes will do good to the library, feel free to merge :)

Oh, and I've also fixed a couple of typos in comments.