### PR TITLE
Add -fireDate to match a similar property on NSTimer

### DIFF
--- a/MSWeakTimer.h
+++ b/MSWeakTimer.h
@@ -54,6 +54,11 @@
 @property (atomic, assign) NSTimeInterval tolerance;
 
 /**
+ *  Adjust the fire date of the timer, useful for repeated timers that need to be offset to a specific time. Equivalent to calling -schedule at the given moment.
+ */
+@property (atomic, strong) NSDate *fireDate;
+
+/**
  * Causes the timer to be fired synchronously manually on the queue from which you call this method.
  * You can use this method to fire a repeating timer without interrupting its regular firing schedule.
  * If the timer is non-repeating, it is automatically invalidated after firing, even if its scheduled fire date has not arrived.


### PR DESCRIPTION
MSWeakTimer is a great replacement for NSTimer, however I did stumble on one scenario which was not carried over from NSTimer.

Namely, when you create a repeating timer, it sometimes makes sense to postpone the start of the timer to some specific moment, whether it be to match the displayed time of the device or some other reason. NSTimer offers -fireDate/-setFireDate for that purpose, so I brought an analogue to MSWeakTimer to replicate the effect.